### PR TITLE
Display a toast message when yt-dlp is updated

### DIFF
--- a/app/src/main/java/org/yausername/dvd/work/YoutubeDLUpdateWorker.kt
+++ b/app/src/main/java/org/yausername/dvd/work/YoutubeDLUpdateWorker.kt
@@ -45,6 +45,12 @@ class YoutubeDLUpdateWorker(appContext: Context, params: WorkerParameters) :
                     .show()
             }
         }
+        if (result == YoutubeDL.UpdateStatus.DONE) {
+            withContext(Dispatchers.Main) {
+                Toast.makeText(applicationContext, R.string.updated_successful, Toast.LENGTH_SHORT)
+                    .show()
+            }
+        }
         return Result.success()
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="youtubedl_update_noti_title">Updating yt-dlp</string>
     <string name="youtubedl_update_noti_channel_name">yt-dlp update</string>
     <string name="already_updated">Already up to date</string>
+    <string name="updated_successful">Update successful</string>
     <string name="command_noti_channel_name">yt-dlp command</string>
     <string name="eta_in_seconds">Task ?/n (ETA %d seconds)</string>
     <string name="fps_value">%d fps</string>


### PR DESCRIPTION
A toast message is displayed if yt-dlp has been updated successfully.