### PR TITLE
Add format conversion

### DIFF
--- a/app/src/main/java/org/yausername/dvd/ui/DownloadPathDialogFragment.kt
+++ b/app/src/main/java/org/yausername/dvd/ui/DownloadPathDialogFragment.kt
@@ -5,19 +5,35 @@ import android.content.Context
 import android.net.Uri
 import android.os.Bundle
 import android.provider.DocumentsContract
+import android.text.Editable
+import android.text.TextWatcher
+import android.widget.EditText
+import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
 import androidx.fragment.app.DialogFragment
 import androidx.preference.PreferenceManager
 import org.yausername.dvd.R
 import kotlinx.android.synthetic.main.dialog_fragment_download_path.view.*
 
-class DownloadPathDialogFragment : DialogFragment() {
+class DownloadPathDialogFragment : DialogFragment(), TextWatcher {
 
     private lateinit var listener: DialogListener
+
+    //It needs to be done this way because the EditText can't be read when the View is destroyed
+    //so instead, we make a separate String and just update it along with the EditText.
+    public var convertFormat: String = ""
 
     interface DialogListener {
         fun onOk(dialog: DownloadPathDialogFragment)
         fun onFilePicker(dialog: DownloadPathDialogFragment)
+    }
+
+    override fun afterTextChanged(s: Editable?) {
+    }
+    override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+    }
+    override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+        convertFormat = s.toString();
     }
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
@@ -26,6 +42,7 @@ class DownloadPathDialogFragment : DialogFragment() {
             val inflater = requireActivity().layoutInflater
 
             val view = inflater.inflate(R.layout.dialog_fragment_download_path, null)
+            view.download_format_name.addTextChangedListener(this)
             val sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context)
             val location = sharedPrefs.getString(getString(R.string.download_location_key), null)
             if (location != null) {
@@ -37,7 +54,7 @@ class DownloadPathDialogFragment : DialogFragment() {
             }
             builder.setView(view)
                 .setIcon(R.drawable.ic_folder_24dp)
-                .setTitle(R.string.download_location_title)
+                .setTitle(R.string.download_options_title)
                 .setNegativeButton(R.string.action_choose_folder)
                 { dialog, id ->
                     listener.onFilePicker(this)
@@ -53,6 +70,7 @@ class DownloadPathDialogFragment : DialogFragment() {
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
+        convertFormat = ""
         try {
             listener = parentFragment as DialogListener
         } catch (e: ClassCastException) {

--- a/app/src/main/java/org/yausername/dvd/ui/DownloadPathDialogFragment.kt
+++ b/app/src/main/java/org/yausername/dvd/ui/DownloadPathDialogFragment.kt
@@ -14,8 +14,9 @@ import androidx.fragment.app.DialogFragment
 import androidx.preference.PreferenceManager
 import org.yausername.dvd.R
 import kotlinx.android.synthetic.main.dialog_fragment_download_path.view.*
+import org.yausername.dvd.model.VidInfoItem
 
-class DownloadPathDialogFragment : DialogFragment(), TextWatcher {
+class DownloadPathDialogFragment(val vidFormat: VidInfoItem.VidFormatItem?) : DialogFragment(), TextWatcher {
 
     private lateinit var listener: DialogListener
 
@@ -43,6 +44,12 @@ class DownloadPathDialogFragment : DialogFragment(), TextWatcher {
 
             val view = inflater.inflate(R.layout.dialog_fragment_download_path, null)
             view.download_format_name.addTextChangedListener(this)
+
+            //remove the conversion field if not downloading *only* audio
+            if (vidFormat == null || !(vidFormat.vidFormat.acodec != "none" && vidFormat.vidFormat.vcodec == "none")) {
+                view.download_format_convs.removeAllViews()
+            }
+
             val sharedPrefs = PreferenceManager.getDefaultSharedPreferences(context)
             val location = sharedPrefs.getString(getString(R.string.download_location_key), null)
             if (location != null) {

--- a/app/src/main/java/org/yausername/dvd/ui/HomeFragment.kt
+++ b/app/src/main/java/org/yausername/dvd/ui/HomeFragment.kt
@@ -59,6 +59,7 @@ class HomeFragment : Fragment(), SearchView.OnQueryTextListener,
         initViews(view)
     }
 
+    var lastAttemptedVidFormat: VidInfoItem.VidFormatItem? = null
     private fun initViews(view: View) {
         val vidFormatsVm =
             ViewModelProvider(activity as MainActivity).get(VidInfoViewModel::class.java)
@@ -67,9 +68,10 @@ class HomeFragment : Fragment(), SearchView.OnQueryTextListener,
                 VidInfoAdapter(VidInfoListener listener@{
                     vidFormatsVm.selectedItem = it
                     if (!isStoragePermissionGranted()) {
+                        lastAttemptedVidFormat = vidFormatsVm.selectedItem
                         return@listener
                     }
-                    DownloadPathDialogFragment().show(
+                    DownloadPathDialogFragment(vidFormatsVm.selectedItem).show(
                         childFragmentManager,
                         downloadLocationDialogTag
                     )
@@ -248,7 +250,7 @@ class HomeFragment : Fragment(), SearchView.OnQueryTextListener,
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
         if (requestCode == 1 && grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-            DownloadPathDialogFragment().show(
+            DownloadPathDialogFragment(lastAttemptedVidFormat).show(
                 childFragmentManager,
                 downloadLocationDialogTag
             )

--- a/app/src/main/java/org/yausername/dvd/ui/HomeFragment.kt
+++ b/app/src/main/java/org/yausername/dvd/ui/HomeFragment.kt
@@ -37,6 +37,7 @@ import org.yausername.dvd.work.DownloadWorker.Companion.urlKey
 import org.yausername.dvd.work.DownloadWorker.Companion.vcodecKey
 import kotlinx.android.synthetic.main.fragment_home.*
 import kotlinx.android.synthetic.main.fragment_home.view.*
+import org.yausername.dvd.work.DownloadWorker.Companion.convertFormatKey
 import org.yausername.dvd.work.DownloadWorker.Companion.taskIdKey
 
 
@@ -141,7 +142,7 @@ class HomeFragment : Fragment(), SearchView.OnQueryTextListener,
                         setDefaultDownloadLocation(it.toString())
                         val vidFormatsVm =
                             ViewModelProvider(activity as MainActivity).get(VidInfoViewModel::class.java)
-                        startDownload(vidFormatsVm.selectedItem, it.toString())
+                        startDownload(vidFormatsVm.selectedItem, it.toString(), "")
                     }
                 }
             }
@@ -155,7 +156,7 @@ class HomeFragment : Fragment(), SearchView.OnQueryTextListener,
             .putString(getString(R.string.download_location_key), path).apply()
     }
 
-    private fun startDownload(vidFormatItem: VidInfoItem.VidFormatItem, downloadDir: String) {
+    private fun startDownload(vidFormatItem: VidInfoItem.VidFormatItem, downloadDir: String, convFormat: String?) {
         val vidInfo = vidFormatItem.vidInfo
         val vidFormat = vidFormatItem.vidFormat
         val workTag = vidInfo.id
@@ -179,7 +180,8 @@ class HomeFragment : Fragment(), SearchView.OnQueryTextListener,
             vcodecKey to vidFormat.vcodec,
             downloadDirKey to downloadDir,
             sizeKey to vidFormat.fileSize,
-            taskIdKey to vidInfo.id
+            taskIdKey to vidInfo.id,
+            convertFormatKey to convFormat
         )
         val workRequest = OneTimeWorkRequestBuilder<DownloadWorker>()
             .addTag(workTag)
@@ -207,7 +209,7 @@ class HomeFragment : Fragment(), SearchView.OnQueryTextListener,
             Toast.makeText(context, R.string.invalid_download_location, Toast.LENGTH_SHORT).show()
             return
         }
-        startDownload(vidFormatsVm.selectedItem, path)
+        startDownload(vidFormatsVm.selectedItem, path, dialog.convertFormat)
     }
 
     override fun onFilePicker(dialog: DownloadPathDialogFragment) {

--- a/app/src/main/java/org/yausername/dvd/work/DownloadWorker.kt
+++ b/app/src/main/java/org/yausername/dvd/work/DownloadWorker.kt
@@ -8,7 +8,6 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.provider.DocumentsContract
-import android.util.Log
 import android.webkit.MimeTypeMap
 import androidx.core.app.NotificationCompat
 import androidx.work.CoroutineWorker
@@ -44,6 +43,7 @@ class DownloadWorker(appContext: Context, params: WorkerParameters) :
         val downloadDir = inputData.getString(downloadDirKey)!!
         val size = inputData.getLong(sizeKey, 0L)
         val taskId = inputData.getString(taskIdKey)!!
+        val convFormat = inputData.getString(convertFormatKey)!!;
 
         createNotificationChannel()
         val notificationId = id.hashCode()
@@ -64,12 +64,22 @@ class DownloadWorker(appContext: Context, params: WorkerParameters) :
         tmpFile.delete()
         tmpFile.mkdir()
         tmpFile.deleteOnExit()
-        request.addOption("-o", "${tmpFile.absolutePath}/${name}.%(ext)s")
         val videoOnly = vcodec != "none" && acodec == "none"
         if (videoOnly) {
             request.addOption("-f", "${formatId}+bestaudio")
         } else {
             request.addOption("-f", formatId)
+        }
+        if (convFormat != ""){
+            if (vcodec != "none"){
+                request.addOption("--format", convFormat);
+            } else {
+                request.addOption("-x", "");
+                request.addOption("--audio-format", convFormat);
+            }
+            request.addOption("-o", "${tmpFile.absolutePath}/${name}.${convFormat}")
+        } else {
+            request.addOption("-o", "${tmpFile.absolutePath}/${name}.%(ext)s")
         }
 
         var destUri: Uri? = null
@@ -179,6 +189,7 @@ class DownloadWorker(appContext: Context, params: WorkerParameters) :
         const val downloadDirKey = "downloadDir"
         const val sizeKey = "size"
         const val taskIdKey = "taskId"
+        const val convertFormatKey = "convFormat"
     }
 }
 

--- a/app/src/main/java/org/yausername/dvd/work/DownloadWorker.kt
+++ b/app/src/main/java/org/yausername/dvd/work/DownloadWorker.kt
@@ -71,16 +71,12 @@ class DownloadWorker(appContext: Context, params: WorkerParameters) :
             request.addOption("-f", formatId)
         }
         if (convFormat != ""){
-            if (vcodec != "none"){
-                request.addOption("--format", convFormat);
-            } else {
-                request.addOption("-x", "");
+            if (vcodec == "none"){
+                request.addOption("-x");
                 request.addOption("--audio-format", convFormat);
             }
-            request.addOption("-o", "${tmpFile.absolutePath}/${name}.${convFormat}")
-        } else {
-            request.addOption("-o", "${tmpFile.absolutePath}/${name}.%(ext)s")
         }
+        request.addOption("-o", "${tmpFile.absolutePath}/${name}.%(ext)s")
 
         var destUri: Uri? = null
         try {

--- a/app/src/main/res/layout/dialog_fragment_download_path.xml
+++ b/app/src/main/res/layout/dialog_fragment_download_path.xml
@@ -7,21 +7,27 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:orientation="vertical">
-        <TextView
+        <LinearLayout
+            android:id="@+id/download_format_convs"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="10dp"
-            android:textStyle="bold"
-            android:text="@string/download_format_name" />
-        <EditText
-            android:id="@+id/download_format_name"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginStart="30dp"
-            android:maxLines="1"
-            android:inputType="text"
-            android:hint="@string/download_convert_hint"/>
+            android:orientation="vertical">
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="20dp"
+                android:layout_marginTop="10dp"
+                android:textStyle="bold"
+                android:text="@string/download_format_name" />
+            <EditText
+                android:id="@+id/download_format_name"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="30dp"
+                android:maxLines="1"
+                android:inputType="text"
+                android:hint="@string/download_convert_hint"/>
+        </LinearLayout>
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/dialog_fragment_download_path.xml
+++ b/app/src/main/res/layout/dialog_fragment_download_path.xml
@@ -20,7 +20,8 @@
             android:layout_height="wrap_content"
             android:layout_marginStart="30dp"
             android:maxLines="1"
-            android:inputType="text"/>
+            android:inputType="text"
+            android:hint="@string/download_convert_hint"/>
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/layout/dialog_fragment_download_path.xml
+++ b/app/src/main/res/layout/dialog_fragment_download_path.xml
@@ -3,11 +3,37 @@
     android:layout_width="wrap_content"
     android:layout_height="wrap_content">
 
-    <TextView
-        android:id="@+id/download_path_tv"
+    <LinearLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_marginStart="30dp"
-        android:layout_marginTop="10dp"
-        android:text="@string/val_not_set" />
+        android:orientation="vertical">
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="10dp"
+            android:textStyle="bold"
+            android:text="@string/download_format_name" />
+        <EditText
+            android:id="@+id/download_format_name"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="30dp"
+            android:maxLines="1"
+            android:inputType="text"/>
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="10dp"
+            android:textStyle="bold"
+            android:text="@string/download_location" />
+        <TextView
+            android:id="@+id/download_path_tv"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="30dp"
+            android:layout_marginTop="10dp"
+            android:text="@string/val_not_set" />
+    </LinearLayout>
 </RelativeLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -15,7 +15,9 @@
     <string name="init_failed">Initialization failed</string>
     <string name="app_not_found">No app found on device for opening this content</string>
     <string name="file_not_found">The selected file does not exist anymore</string>
-    <string name="download_location_title">Download location</string>
+    <string name="download_options_title">Download options</string>
+    <string name="download_location">Download location</string>
+    <string name="download_format_name">Convert to… (optional)</string>
     <string name="action_choose_folder">Choose folder</string>
     <string name="download_already_running">A download is already running</string>
     <string name="download_queued">Download queued. Check notification for progress</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="download_options_title">Download options</string>
     <string name="download_location">Download location</string>
     <string name="download_format_name">Convert to… (optional)</string>
+    <string name="download_convert_hint">(mp3, wav, etc.)</string>
     <string name="action_choose_folder">Choose folder</string>
     <string name="download_already_running">A download is already running</string>
     <string name="download_queued">Download queued. Check notification for progress</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -9,7 +9,7 @@
 
     <Preference
         android:key="@string/download_location_key"
-        android:title="@string/download_location_title"
+        android:title="@string/download_location"
         app:iconSpaceReserved="false"></Preference>
 
     <Preference


### PR DESCRIPTION
This PR adds a conversion format text field to the pre-download popup.
For videos, this corresponds to the `--format` youtube-dl argument, and for audio, to `-x --audio-format`
![unknown](https://user-images.githubusercontent.com/33550839/189046845-b6feafce-0bae-477e-b19e-420203150b2b.png)
